### PR TITLE
address security vulnerabilities in dependencies

### DIFF
--- a/src/Faithlife.Utility.Dapper/Faithlife.Utility.Dapper.csproj
+++ b/src/Faithlife.Utility.Dapper/Faithlife.Utility.Dapper.csproj
@@ -25,8 +25,19 @@
     <PackageReference Include="Dapper" Version="1.50.2" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="SourceLink.Test" Version="2.0.2" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.0.2" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Data.SqlClient">
+      <Version>4.8.6</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Security">
+      <Version>4.3.2</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Faithlife.Utility.Dapper/Faithlife.Utility.Dapper.csproj
+++ b/src/Faithlife.Utility.Dapper/Faithlife.Utility.Dapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Version>1.1.0</Version>
     <Authors>Faithlife Corporation</Authors>
@@ -22,22 +22,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.0.2" PrivateAssets="all" />
     <PackageReference Include="SourceLink.Test" Version="2.0.2" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.0.2" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.0.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Data.SqlClient">
-      <Version>4.8.6</Version>
-    </PackageReference>
-    <PackageReference Include="System.Net.Security">
-      <Version>4.3.2</Version>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/Faithlife.Utility.Dapper.Tests/Faithlife.Utility.Dapper.Tests.csproj
+++ b/tests/Faithlife.Utility.Dapper.Tests/Faithlife.Utility.Dapper.Tests.csproj
@@ -1,14 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This package has [transitive, via Dapper version] references to very old packages and has at least 10 known moderate and high security vulnerabilities as a result.

https://github.com/advisories/GHSA-7jgj-8wvc-jh57
https://github.com/advisories/GHSA-8g2p-5pqh-5jmc
https://github.com/advisories/GHSA-98g6-xh36-x2p7
https://github.com/advisories/GHSA-cmhx-cq75-c4mj
https://github.com/advisories/GHSA-6xh7-4v2w-36q6
https://github.com/advisories/GHSA-qhqf-ghgh-x2m4
https://github.com/advisories/GHSA-ch6p-4jcm-h8vh
https://github.com/advisories/GHSA-j8f4-2w4p-mhjc

(test package)
https://github.com/advisories/GHSA-7mfr-774f-w5r9
https://github.com/advisories/GHSA-8884-xcr4-r68p

I updated the package references, and updated the test project to an in-support framework and other dependencies just to be able to be able to run it.